### PR TITLE
fix: Bei deaktivierter TSE sollte der bisherige Ablauf nicht unterbrochen werden

### DIFF
--- a/erpnext_tse/erpnext_tse/doctype/tse_transaction/tse_transaction.py
+++ b/erpnext_tse/erpnext_tse/doctype/tse_transaction/tse_transaction.py
@@ -306,6 +306,9 @@ def create_tse_transaction_for_pos_invoice(doc, method: str | None = None):
 	if doc.doctype != "POS Invoice":
 		return
 
+	if not frappe.db.get_single_value("TSE Settings", "enabled"):
+		return
+
 	# 3. POS Profile holen
 	if not getattr(doc, "pos_profile", None):
 		frappe.throw(_("POS Invoice is missing a POS Profile."))

--- a/erpnext_tse/erpnext_tse/pos/pos_invoice/pos_invoice_hooks.py
+++ b/erpnext_tse/erpnext_tse/pos/pos_invoice/pos_invoice_hooks.py
@@ -5,7 +5,13 @@ import frappe
 from frappe import _
 
 
+def _is_tse_enabled():
+	return bool(frappe.db.get_single_value("TSE Settings", "enabled"))
+
+
 def ensure_tse_transaction_present_and_finished(doc, method):
+	if not _is_tse_enabled():
+		return
 	# Sicherstellen, dass eine TSE Transaction vorhanden ist und den Status Finished hat
 	# Ohne sollte um auch rechtlich sicher zu sein keine Buchung erfolgen
 	if not doc.tse_transaction:
@@ -30,6 +36,8 @@ def show_tse_signing_success_toast(doc, method=None):
 	- Grün: TSE Transaction FINISHED
 	- Rot + Abbruch: TSE Transaction hat nicht Status FINISHED oder andere Fehler
 	"""
+	if not _is_tse_enabled():
+		return
 
 	# Keine verknüpfte TSE Transaction
 	if not getattr(doc, "tse_transaction", None):

--- a/erpnext_tse/erpnext_tse/pos/pos_invoice/test_pos_invoice_hooks.py
+++ b/erpnext_tse/erpnext_tse/pos/pos_invoice/test_pos_invoice_hooks.py
@@ -14,34 +14,39 @@ class TestPosInvoiceHooks(FrappeTestCase):
 	def test_ensure_requires_transaction(self):
 		doc = SimpleNamespace(tse_transaction=None)
 
-		with self.assertRaises(frappe.MandatoryError):
-			pos_invoice_hooks.ensure_tse_transaction_present_and_finished(doc, None)
+		with patch("frappe.db.get_single_value", return_value=1):
+			with self.assertRaises(frappe.MandatoryError):
+				pos_invoice_hooks.ensure_tse_transaction_present_and_finished(doc, None)
 
 	def test_ensure_requires_finished(self):
 		doc = SimpleNamespace(tse_transaction="TX-1")
 
-		with patch("frappe.get_doc", return_value=SimpleNamespace(transaction_status="ACTIVE")):
-			with self.assertRaises(frappe.ValidationError):
-				pos_invoice_hooks.ensure_tse_transaction_present_and_finished(doc, None)
+		with patch("frappe.db.get_single_value", return_value=1):
+			with patch("frappe.get_doc", return_value=SimpleNamespace(transaction_status="ACTIVE")):
+				with self.assertRaises(frappe.ValidationError):
+					pos_invoice_hooks.ensure_tse_transaction_present_and_finished(doc, None)
 
 	def test_ensure_passes_finished(self):
 		doc = SimpleNamespace(tse_transaction="TX-1")
 
-		with patch("frappe.get_doc", return_value=SimpleNamespace(transaction_status="FINISHED")):
-			pos_invoice_hooks.ensure_tse_transaction_present_and_finished(doc, None)
+		with patch("frappe.db.get_single_value", return_value=1):
+			with patch("frappe.get_doc", return_value=SimpleNamespace(transaction_status="FINISHED")):
+				pos_invoice_hooks.ensure_tse_transaction_present_and_finished(doc, None)
 
 	def test_show_toast_requires_transaction(self):
 		doc = SimpleNamespace(tse_transaction=None)
 
-		with self.assertRaises(frappe.ValidationError):
-			pos_invoice_hooks.show_tse_signing_success_toast(doc)
+		with patch("frappe.db.get_single_value", return_value=1):
+			with self.assertRaises(frappe.ValidationError):
+				pos_invoice_hooks.show_tse_signing_success_toast(doc)
 
 	def test_show_toast_success(self):
 		doc = SimpleNamespace(tse_transaction="TX-1")
 		tse_doc = SimpleNamespace(name="TX-1", transaction_status="FINISHED")
 
-		with patch("frappe.get_doc", return_value=tse_doc), patch("frappe.msgprint") as msgprint:
-			pos_invoice_hooks.show_tse_signing_success_toast(doc)
+		with patch("frappe.db.get_single_value", return_value=1):
+			with patch("frappe.get_doc", return_value=tse_doc), patch("frappe.msgprint") as msgprint:
+				pos_invoice_hooks.show_tse_signing_success_toast(doc)
 
 		_, kwargs = msgprint.call_args
 		self.assertEqual(kwargs.get("indicator"), "green")
@@ -50,6 +55,19 @@ class TestPosInvoiceHooks(FrappeTestCase):
 		doc = SimpleNamespace(tse_transaction="TX-1")
 		tse_doc = SimpleNamespace(name="TX-1", transaction_status="ACTIVE")
 
-		with patch("frappe.get_doc", return_value=tse_doc):
-			with self.assertRaises(frappe.ValidationError):
-				pos_invoice_hooks.show_tse_signing_success_toast(doc)
+		with patch("frappe.db.get_single_value", return_value=1):
+			with patch("frappe.get_doc", return_value=tse_doc):
+				with self.assertRaises(frappe.ValidationError):
+					pos_invoice_hooks.show_tse_signing_success_toast(doc)
+
+	def test_ensure_skips_when_disabled(self):
+		doc = SimpleNamespace(tse_transaction=None)
+
+		with patch("frappe.db.get_single_value", return_value=0):
+			pos_invoice_hooks.ensure_tse_transaction_present_and_finished(doc, None)
+
+	def test_show_toast_skips_when_disabled(self):
+		doc = SimpleNamespace(tse_transaction=None)
+
+		with patch("frappe.db.get_single_value", return_value=0):
+			pos_invoice_hooks.show_tse_signing_success_toast(doc)


### PR DESCRIPTION
Erst bei aktiverter TSE sollen Hooks sowie die Validierung von POS Invoice Submits greifen